### PR TITLE
updated Juror Digital tag to match tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -156,7 +156,7 @@ juror-digital:
     contact_channel: ""
     build_notices_channel: ""
   tags:
-    application: "Juror Digital"
+    application: "juror-digital"
     businessArea: "Cross-Cutting"
 ctsc:
   team: "CTSC"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-7853

### Change description ###

Application tag updated for Juror Digital to match agreed name within the tagging dictionary - https://tools.hmcts.net/confluence/display/DCO/Tagging+v0.4

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
