### PR TITLE
DTSPO-17731 - change expiresAfter default days

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,10 @@ locals {
     autoShutdown = var.autoShutdown
     startupMode  = var.startupMode
   }
+  # if var.expiresAfter set to "0000-00-00", set default date to date of creation + 14 days
+  expiresAfter = var.expiresAfter == "0000-00-00" ? formatdate("YYYY-MM-DD", timeadd(timestamp(), "336h")) : var.expiresAfter
+  all_tags     = local.common_tags.environment == "sandbox" ? merge(local.common_tags, local.additional_tags, tomap({ "expiresAfter" = local.expiresAfter })) : merge(local.common_tags, local.additional_tags)
 
-  expiresAfter = var.expiresAfter == "0000-00-00" ? formatdate("YYYY-MM-DD", timeadd(timestamp(), "720h")) : var.expiresAfter
-  all_tags = local.common_tags.environment == "sandbox" ? merge(local.common_tags, local.additional_tags, tomap({"expiresAfter" = local.expiresAfter})) : merge(local.common_tags, local.additional_tags)
-  
   criticality = {
     sbox     = "Low"
     aat      = "High"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17731

### Change description ###

Updated default days for expiresAfter tag from 30 days to 14 days.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

