### PR TITLE
DTSPO18094 - Make startupMode optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
 
   additional_tags = {
     autoShutdown = var.autoShutdown
-    startupMode  = var.startupMode
+    startupMode  = var.autoShutdown == true ? var.startupMode : null
   }
   # if var.expiresAfter set to "0000-00-00", set default date to date of creation + 14 days
   expiresAfter = var.expiresAfter == "0000-00-00" ? formatdate("YYYY-MM-DD", timeadd(timestamp(), "336h")) : var.expiresAfter


### PR DESCRIPTION
### Jira link

See [DTSPO-18904](https://tools.hmcts.net/jira/browseDTSPO-18904)

### Change description

`startupMode` is being set to a default value even when autoShutdown isn't being performed.
This causes machines that have been shut down manually in preparation for decommission to be started up again.
Making `startupMode` an optional value that will be created only if `autoShutdown` is set to `true`.

Example of when `autoShutdown` is `false`: 
![Screenshot 2025-03-11 at 09 19 41](https://github.com/user-attachments/assets/276fc722-3f69-4ed0-a254-cb64314bd090)

Example of when `autoShutdown` is `true`:
![Screenshot 2025-03-11 at 09 19 53](https://github.com/user-attachments/assets/5c93dddd-43e4-45d7-94c4-9dd327495109)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
